### PR TITLE
Fix encoding, syntax, and support for windows line-endings in .lvm files

### DIFF
--- a/lvm_read.py
+++ b/lvm_read.py
@@ -64,6 +64,7 @@ def _read_lvm_base(filename):
     :return lvm_data: lvm dict
     """
     lvm_data = dict()
+    lvm_data['Decimal_Separator'] = '.'
     f = open(filename, 'r')
     data_channels_comment_reading = False
     data_reading = False
@@ -72,6 +73,7 @@ def _read_lvm_base(filename):
     nr_of_columns = 0
     segment_nr = 0
     for line in f:
+        line = line.replace('\r', '')
         line_sp = line.replace('\n', '').split('\t')
         if line_sp[0] in ['***End_of_Header***', 'LabVIEW Measurement']:
             continue
@@ -106,7 +108,7 @@ def _read_lvm_base(filename):
                 data_channels_comment_reading = False
                 data_reading = True
             elif data_channels_comment_reading:
-                key, *values = line_sp[:(nr_of_columns + 1)]
+                key, values = line_sp[0], line_sp[1:(nr_of_columns + 1)]
                 if key in ['Delta_X', 'X0', 'Samples']:
                     segment[key] = [eval(val.replace(lvm_data['Decimal_Separator'], '.')) if val else np.nan for val in values]
                 else:

--- a/lvm_read.py
+++ b/lvm_read.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 
 # Copyright (C) 2014-2017 Matjaž Mršnik, Miha Pirnat, Janko Slavič, Blaž Starc (in alphabetic order)
 #

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 
 # Copyright (C) 2014-2017 Matjaž Mršnik, Miha Pirnat, Janko Slavič, Blaž Starc (in alphabetic order)
 #

--- a/test_more.py
+++ b/test_more.py
@@ -1,0 +1,55 @@
+"""
+Unit test for lvm_read.py
+"""
+
+import numpy as np
+from lvm_read import read
+import os
+import io
+
+def test_1():
+    lvm="""\
+LabVIEW Measurement	
+Writer_Version	0.92
+Reader_Version	1
+Separator	Tab
+Multi_Headings	Yes
+X_Columns	Multi
+Time_Pref	Absolute
+Operator	mt
+Date	2016/12/12
+Time	09:54:07,284627
+***End_of_Header***	
+	
+Channels	3					
+Samples	4		4		4	
+Date	2016/12/12		2016/12/12		2016/12/12	
+Time	09:54:07,483999		09:54:07,483999		09:54:07,483999	
+Y_Unit_Label	g		g		g	
+X_Dimension	Time		Time		Time	
+X0	0.0000000000000000E+0		0.0000000000000000E+0		0.0000000000000000E+0	
+Delta_X	0.000250		0.000250		0.000250	
+***End_of_Header***						
+X_Value	ax	X_Value	ay	X_Value	az	Comment
+0.000000	-0.008807	0.000000	-0.028189	0.000000	0.021503
+0.000250	-0.025979	0.000250	-0.031060	0.000250	-0.005606
+0.000500	-0.011987	0.000500	-0.013517	0.000500	0.007789
+0.000750	0.059248	0.000750	-0.021172	0.000750	-0.009433
+
+"""
+    f = open('test.lvm', 'w')
+    f.write(lvm)
+    f.close()
+    data = read('test.lvm', read_from_pickle=False, dump_file=False)
+    np.testing.assert_equal(data[0]['data'][0,1],-0.008807)
+
+    f = io.open('test.lvm', 'w', newline='\r\n')
+    f.write(unicode(lvm))
+    f.close()
+    data = read('test.lvm', read_from_pickle=False, dump_file=False)
+    np.testing.assert_equal(data[0]['data'][0,1],-0.008807)
+
+    os.remove('test.lvm')
+
+if __name__ == '__main__':
+    np.testing.run_module_suite()


### PR DESCRIPTION
- I got errors if the decimal_separator field was not set
- utf8 characters in the code meant that I could not import the module.
- the *-syntax did not work with Python 2.7
- it did not support windows line-endings in the .lvm file

I created a unit test for the latter.

You evidently use unit tests, but your data files are not in the git repository, so I could not use them.